### PR TITLE
Fix several bugs

### DIFF
--- a/split-mysql-dump.rb
+++ b/split-mysql-dump.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
  
 require 'optparse'
  
@@ -10,86 +10,102 @@ cmds = OptionParser.new do |opts|
   opts.banner = "Usage: split-mysql-dump.rb [options] [FILE]"
 
   opts.on("-s", "Read from stdin") do
-    dumpfile = $stdin
+  dumpfile = $stdin
   end
   
   opts.on("-t", '--tables TABLES', Array, "Extract only these tables") do |t|
-      tables = t
+    tables = t
   end
   
   opts.on("-i", '--ignore-tables TABLES', Array, "Ignore these tables") do |i|
-      ignore = i
+    ignore = i
   end
   
   opts.on_tail("-h", "--help") do
-    puts opts
+  puts opts
   end
 
 end.parse!
 
 if dumpfile == ""
-    dumpfile = ARGV.shift
-    if not dumpfile
-        puts "Nothing to do"
-        exit 
-    end
+  dumpfile = ARGV.shift
+  if not dumpfile
+    puts "Nothing to do"
+    exit 
+  end
 end
 
 STDOUT.sync = true
  
 class Numeric
-    def bytes_to_human
-        units = %w{B KB MB GB TB}
-        e = (Math.log(self)/Math.log(1024)).floor
-        s = "%.3f" % (to_f / 1024**e)
-        s.sub(/\.?0*$/, units[e])
-    end
+  def bytes_to_human
+    units = %w{B KB MB GB TB}
+    e = self > 0 ? (Math.log(self)/Math.log(1024)).floor : 0
+    s = "%.3f" % (to_f / 1024**e)
+    s.sub(/\.?0*$/, units[e])
+  end
 end
 
 if File.exist?(dumpfile)
-    if dumpfile == $stdin
-        d = $stdin
-    else
-        d = File.new(dumpfile, "r")
+  if dumpfile == $stdin
+    d = $stdin
+  else
+    d = File.new(dumpfile, "r")
+  end
+ 
+  outfile = nil
+  table = nil
+  db = nil
+  linecount = tablecount = starttime = 0
+ 
+  while (line = d.gets)
+    # Detect table changes
+    if line =~ /^-- Table structure for table .(.+)./ or line =~ /^-- Dumping data for table .(.+)./
+      is_new_table = table != $1
+      table = $1
+
+      # previous file should be closed
+      if is_new_table
+        outfile.close if outfile and !outfile.closed?
+
+        puts("\n\nFound a new table: #{table}")
+
+        if (tables != [] and not tables.include?(table))
+          puts"`#{table}` not in list, ignoring"
+          table = nil
+        elsif (ignore != [] and ignore.include?(table))
+          puts"`#{table}` will be ignored"
+          table = nil
+        else
+          starttime = Time.now
+          linecount = 0
+          tablecount += 1
+          outfile = File.new("#{db}_#{table}.sql", "w")
+          outfile.syswrite("USE `#{db}`;\n\n")
+        end
+      end
+    elsif line =~ /^-- Current Database: .(.+)./
+      db = $1
+      table = nil
+      outfile.close if outfile and !outfile.closed?
+      outfile = File.new("#{db}_1create.sql", "w")
+      puts("\n\nFound a new db: #{db}")
+    elsif line =~ /^-- Position to start replication or point-in-time recovery from/
+      db = nil
+      table = nil
+      outfile.close if outfile and !outfile.closed?
+      outfile = File.new("1replication.sql", "w")
+      puts("\n\nFound replication data")
     end
  
-    outfile = false
-    table = ""
-    db = ""
-    linecount = tablecount = starttime = 0
- 
-    while (line = d.gets)
-        if line =~ /^-- Table structure for table .(.+)./ or line =~ /^-- Dumping data for table .(.+)./
-            table = $1
-            linecount = 0
-            tablecount += 1
- 
-            puts("\n\n") if outfile
- 
-            puts("Found a new table: #{table}")
-            if (tables != [] and not tables.include?(table))
-                puts"`#{table}` not in list, ignoring"
-                table = ""
-            elsif (ignore != [] and ignore.include?(table))
-                puts"`#{table}` will be ignored"
-                table = ""
-            end 
-            starttime = Time.now
-            if table != ""
-                outfile = File.new("#{db}_#{table}.sql", "w")
-            end
-        elsif line =~ /^USE .(.+).;/
-            db = $1
-            puts("Found a new db: #{db}")
-        end
- 
-        if table != "" && outfile
-            outfile.syswrite line
-            linecount += 1
-            elapsed = Time.now.to_i - starttime.to_i + 1
-            print("    writing line: #{linecount} #{outfile.stat.size.bytes_to_human} in #{elapsed} seconds #{(outfile.stat.size / elapsed).bytes_to_human}/sec                 \r")
-        end
+    # Write line to outfile
+    if outfile and !outfile.closed?
+      outfile.syswrite(line)
+      linecount += 1
+      elapsed = Time.now.to_i - starttime.to_i + 1
+      print("    writing line: #{linecount} #{outfile.stat.size.bytes_to_human} in #{elapsed} seconds #{(outfile.stat.size / elapsed).bytes_to_human}/sec                 \r")
     end
+  end
 end
  
 puts


### PR DESCRIPTION
Put query to set replication into 1replication.sql
Put queries to create databases into dbname_1create.sql
Prevent script from re-writting SQL files when mysql-dump contains both table and insert statements
Switch to correct database in every split file before inserting data

Note: sorry I switched to a 2 spaces indentation which tends to be common in Ruby script and forgot to change it back.
