### PR TITLE
Revert "Option to add newlines between inserted rows."

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -27,13 +27,6 @@ for working with large gzipped backups:
 $ gunzip -c db.sql.gz | ruby split-mysql-dump.rb -s
 </pre>
 
-If you store your dump files in a version control system (like git) you can add
-newlines between inserted rows for easier-to-read diffs:
-
-<pre>
-$ ruby split-mysql-dump.rb -n db.sql
-</pre>
-
 You can also limit the dump to particular tables using '-t' 
 or exclude tables using '-i'. 
 

--- a/split-mysql-dump.rb
+++ b/split-mysql-dump.rb
@@ -2,7 +2,6 @@
  
 require 'optparse'
  
-addNewlines = false
 tables = []
 ignore = []
 use_database = nil
@@ -15,10 +14,6 @@ cmds = OptionParser.new do |opts|
   dumpfile = $stdin
   end
   
-  opts.on("-n", "--newlines", "Add newlines between inserted rows") do
-    addNewlines = true
-  end
-
   opts.on("-t", '--tables TABLES', Array, "Extract only these tables") do |t|
     tables = t
   end
@@ -69,11 +64,6 @@ if File.exist?(dumpfile)
   linecount = tablecount = starttime = 0
  
   while (line = d.gets)
-    # Add newlines between inserted rows if desired.
-    newLine = (addNewlines and line =~ /^INSERT INTO /) \
-      ? line.gsub(/([^\\])\(/, "\\1\n(") \
-      : line
-
     # Detect table changes
     if line =~ /^-- Table structure for table .(.+)./ or line =~ /^-- Dumping data for table .(.+)./
       is_new_table = table != $1
@@ -117,7 +107,7 @@ if File.exist?(dumpfile)
  
     # Write line to outfile
     if outfile and !outfile.closed?
-      outfile.syswrite(newLine)
+      outfile.syswrite(line)
       linecount += 1
       elapsed = Time.now.to_i - starttime.to_i + 1
       print("    writing line: #{linecount} #{outfile.stat.size.bytes_to_human} in #{elapsed} seconds #{(outfile.stat.size / elapsed).bytes_to_human}/sec                 \r")


### PR DESCRIPTION
This reverts commit 222a4f36dd3312afefa0ba528f2823df95e41db3.

The option has a bug that fails on embedded parentheses.

Mea culpa.  I did not adequately test my previous patch before submitting a pull request and now I've discovered it has a bug.  I am choosing to revert the patch rather than fix the bug for the following reason:

I originally wanted to insert newlines between inserted rows because I read that the easier solution, using `mysqldump --extended-insert=false`, is much slower when restoring a database.  I was concerned about minimizing downtime on an actively used system.

I have since learned there is an even better solution, which is to restore to a temporary database and then rename it using a utility such as [Rename-MySQL-DB](https://github.com/cclark/Rename-MySQL-DB).  This is much faster than my original patch could ever hope to be.
