### PR TITLE
Update split-mysql-dump.rb

### DIFF
--- a/split-mysql-dump.rb
+++ b/split-mysql-dump.rb
@@ -93,8 +93,12 @@ if File.exist?(dumpfile)
       db = $1
       table = nil
       outfile.close if outfile and !outfile.closed?
-      Dir.mkdir(db)
-      Dir.mkdir("#{db}/tables")
+      begin
+        Dir.mkdir(db)
+        Dir.mkdir("#{db}/tables")
+      rescue
+        # Catch errors
+      end
       outfile = File.new("#{db}/create.sql", "w")
       puts("\n\nFound a new db: #{db}")
     elsif line =~ /^-- Position to start replication or point-in-time recovery from/


### PR DESCRIPTION
Catch errors thrown from Dir.mkdir.

The script died for me because directories already existed. This helped.

I haven't investigated why I had several "Current Database" for the same database, so maybe the problem would better be solved in another way.
