### PR TITLE
Fix an issue with path construction

### DIFF
--- a/split-mysql-dump.rb
+++ b/split-mysql-dump.rb
@@ -40,9 +40,6 @@ if dumpfile == ""
   end
 end
 
-db =  Dir.pwd
-Dir.mkdir( "#{db}/tables" )
-
 STDOUT.sync = true
  
 class Numeric
@@ -88,8 +85,9 @@ if File.exist?(dumpfile)
           starttime = Time.now
           linecount = 0
           tablecount += 1
-          db =  Dir.pwd
-          outfile = File.new("#{db}/tables/#{table}.sql", "w")
+          path = (db.to_s == "" ? "" : "#{db}/") + "tables";
+          Dir.mkdir(path) unless File.exists?(path)
+          outfile = File.new("#{path}/#{table}.sql", "w")
           outfile.syswrite("USE `#{db}`;\n\n")
         end
       end


### PR DESCRIPTION
The individual table dumps were all written into the ./tables directory instead of to ./$DB/tables, even when the DB could be inferred from the dump file or was explicitly provided with the -u option. This was especially problematic for dump files containing multiple tables with the same name from different DBs, as the table dumps would overwrite the previous one.
