### PR TITLE
Force binary encoding when reading the input file

### DIFF
--- a/split-mysql-dump.rb
+++ b/split-mysql-dump.rb
@@ -55,7 +55,7 @@ if File.exist?(dumpfile)
   if dumpfile == $stdin
     d = $stdin
   else
-    d = File.new(dumpfile, "r")
+    d = File.new(dumpfile, "r:binary")
   end
  
   outfile = nil


### PR DESCRIPTION
1) it is faster a bit
2) prevents encoding errors
